### PR TITLE
check gpu availibility

### DIFF
--- a/create_env.sh
+++ b/create_env.sh
@@ -44,3 +44,5 @@ fi
 
 cd scripts/prov_crate
 docker build . -t prov_crate
+
+docker pull ubuntu:20.04

--- a/data/dags/pipeline.py
+++ b/data/dags/pipeline.py
@@ -441,7 +441,7 @@ def gather_report(dag_info):
 @task
 def generate_rocrate(input_dir: str):
     command = f"-v {input_dir}:{input_dir} prov_crate  -o {input_dir}/rocrate {input_dir}".split()
-    _docker_run(command)
+    docker_run(command)
 
 
 dag = create_dag()

--- a/docker-compose.promort.yaml
+++ b/docker-compose.promort.yaml
@@ -3,7 +3,6 @@ version: '3'
 services:
 
   promort-db:
-    container_name: promort-db
     image: postgres:9.6.12-alpine
     networks:
       deephealth:
@@ -17,7 +16,6 @@ services:
       - ./data/promort-pg-data:/var/lib/postgresql/data
 
   promort-web:
-    container_name: promort-web
     image: promort-web:dev
     build:
       context: ./build/promort

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,6 @@ services:
         context: ./build/cwl-airflow/packaging/docker_compose/local_executor/cwl_airflow
         args: 
           CWL_AIRFLOW_VERSION: *cwl_airflow_branch
-      container_name: scheduler
       volumes:  # can't reuse *airflow_volumes as YAML doesn't support sequence merging
           - /var/run/docker.sock:/var/run/docker.sock
           - ${AIRFLOW_HOME}:${AIRFLOW_HOME}
@@ -87,7 +86,6 @@ services:
         context: ./build/cwl-airflow/packaging/docker_compose/local_executor/cwl_airflow
         args: 
           CWL_AIRFLOW_VERSION: *cwl_airflow_branch
-      container_name: webserver
       ports:
           - ${AIRFLOW_WEBSERVER_PORT}:8080
       <<: *airflow_volumes
@@ -146,7 +144,6 @@ services:
         context: ./build/cwl-airflow/packaging/docker_compose/local_executor/cwl_airflow
         args: 
           CWL_AIRFLOW_VERSION: *cwl_airflow_branch
-      container_name: init
       volumes:  # can't reuse *airflow_volumes as YAML doesn't support sequence merging
         - ${AIRFLOW_HOME}:${AIRFLOW_HOME}
         - ./scripts/:/scripts

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,8 @@ x-aliases:  # if it starts with x- it's ignored by docker-compose
             - AIRFLOW_USER=${AIRFLOW_USER}
             - AIRFLOW_PASSWORD=${AIRFLOW_PASSWORD}
             - CWLDOCKER_GPUS=$CWLDOCKER_GPUS
+            - CWLDOCKER_ENV=$CWLDOCKER_ENV
+            - CWLDOCKER_PID=$CWLDOCKER_PID
             - INPUT_DIR=${INPUT_DIR}
             - FAILED_DIR=${FAILED_DIR}
             - BACKUP_DIR=${BACKUP_DIR}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -107,7 +107,6 @@ services:
         context: ./build/cwl-airflow/packaging/docker_compose/local_executor/cwl_airflow
         args: 
           CWL_AIRFLOW_VERSION: *cwl_airflow_branch
-      container_name: apiserver
       ports:
           - ${CWL_AIRFLOW_API_PORT}:8081
       <<: *airflow_volumes        


### PR DESCRIPTION
Before running the Predictions task, gpu availibility (i.e. no running processes) is checked.
It is done at pipeline level using a docker container with the parameter --pid=host. It should have been done on the slaid library, but passing the --pid parameter to the related container is tricky and required the custom version of cwltool (which I hope to drop very soon) to be maintained even after gpu support will be add to cwl.
This PR closes #32 .