### PR TITLE
Update provenance RO-Crate

### DIFF
--- a/scripts/prov_crate/gen_crate.py
+++ b/scripts/prov_crate/gen_crate.py
@@ -49,12 +49,17 @@ WORKFLOW_URL = "https://github.com/crs4/deephealth-pipelines"
 WORKFLOW_LICENSE = "MIT"
 TYPE_MAP = {
     "string": "Text",
-    "int": "Number",
-    "long": "Number",
-    "float": "Number",
-    "double": "Number",
+    "int": "Integer",
+    "long": "Integer",
+    "float": "Float",
+    "double": "Float",
+    "Any": "Thing",
+    "boolean": "Boolean",
     "File": "File",
+    "Directory": "Dataset",
 }
+MIRAX_URL = "https://openslide.org/formats/mirax/"
+ZARR_URL = "https://zarr.readthedocs.io/en/stable/spec/v2.html"
 
 
 def get_metadata(source):
@@ -109,10 +114,11 @@ def add_params(params, param_types, metadata, source, crate, action):
     workflow = crate.mainEntity
     inputs, outputs, objects, results = [], [], [], []
     for k, v in params.items():
+        add_type = MIRAX_URL if k == "slide" else param_types[k]
         in_ = crate.add(ContextEntity(crate, f"#param-{k}", properties={
             "@type": "FormalParameter",
             "name": k,
-            "additionalType": param_types[k],
+            "additionalType": add_type,
         }))
         inputs.append(in_)
         if isinstance(v, dict) and v.get("class") == "File":
@@ -120,7 +126,7 @@ def add_params(params, param_types, metadata, source, crate, action):
         else:
             obj = crate.add(ContextEntity(crate, f"#pv-{k}", properties={
                 "@type": "PropertyValue",
-                "additionalType": param_types[k],
+                "additionalType": add_type,
                 "name": k,
                 "value": v,
             }))
@@ -133,7 +139,7 @@ def add_params(params, param_types, metadata, source, crate, action):
         out = crate.add(ContextEntity(crate, f"#param-{k}", properties={
             "@type": "FormalParameter",
             "name": k,
-            "additionalType": "File",
+            "additionalType": ZARR_URL,
         }))
         outputs.append(out)
         path = source / v["location"]

--- a/scripts/prov_crate/gen_crate.py
+++ b/scripts/prov_crate/gen_crate.py
@@ -90,6 +90,25 @@ def get_param_types(params, wf_def):
     return rval
 
 
+def add_action(crate, metadata):
+    start_date = metadata["start_date"].isoformat()
+    end_date = metadata["end_date"].isoformat()
+    workflow = crate.mainEntity
+    properties = {
+        "@type": "CreateAction",
+        "name": f"Promort prediction run on {start_date}",
+        "startTime": start_date,
+        "endTime": end_date,
+        # "instrument": workflow,
+        # "object": workflow["input"],
+        # "result": workflow["output"],
+    }
+    action = crate.add(ContextEntity(crate, properties=properties))
+    action["instrument"] = workflow
+    action["object"] = workflow["input"]
+    action["result"] = workflow["output"]
+
+
 def make_crate(source, out_dir):
     metadata = get_metadata(source)
     workflow_path = source / metadata["workflow"]
@@ -137,7 +156,7 @@ def make_crate(source, out_dir):
         }
         crate.add_file(path, v["location"], properties=properties)
     workflow["output"] = outputs
-    # TODO: store start_date and end_date somewhere
+    add_action(crate, metadata)
     crate.write(out_dir)
 
 

--- a/scripts/prov_crate/gen_crate.py
+++ b/scripts/prov_crate/gen_crate.py
@@ -109,7 +109,7 @@ def add_params(params, param_types, metadata, source, crate, action):
     workflow = crate.mainEntity
     inputs, outputs, objects, results = [], [], [], []
     for k, v in params.items():
-        in_ = crate.add(ContextEntity(crate, properties={
+        in_ = crate.add(ContextEntity(crate, f"#param-{k}", properties={
             "@type": "FormalParameter",
             "name": k,
             "additionalType": param_types[k],
@@ -118,7 +118,7 @@ def add_params(params, param_types, metadata, source, crate, action):
         if isinstance(v, dict) and v.get("class") == "File":
             obj = crate.add_file(v["path"])
         else:
-            obj = crate.add(ContextEntity(crate, properties={
+            obj = crate.add(ContextEntity(crate, f"#pv-{k}", properties={
                 "@type": "PropertyValue",
                 "additionalType": param_types[k],
                 "name": k,
@@ -129,7 +129,8 @@ def add_params(params, param_types, metadata, source, crate, action):
     action["object"] = objects
     for k, v in metadata["outs"].items():
         assert v["class"] == "File"
-        out = crate.add(ContextEntity(crate, properties={
+        assert k not in params  # so that IDs are unique
+        out = crate.add(ContextEntity(crate, f"#param-{k}", properties={
             "@type": "FormalParameter",
             "name": k,
             "additionalType": "File",

--- a/scripts/prov_crate/requirements.txt
+++ b/scripts/prov_crate/requirements.txt
@@ -1,3 +1,3 @@
 cwl-utils==0.13
-rocrate==0.5.2
+rocrate==0.5.5
 pyyaml~=5.4.0

--- a/scripts/prov_crate/tests/expected_output/ro-crate-metadata.json
+++ b/scripts/prov_crate/tests/expected_output/ro-crate-metadata.json
@@ -4,7 +4,7 @@
         {
             "@id": "./",
             "@type": "Dataset",
-            "datePublished": "2021-12-23T09:58:30+00:00",
+            "datePublished": "2022-02-15T10:41:32+00:00",
             "hasPart": [
                 {
                     "@id": "predictions.cwl"
@@ -29,9 +29,14 @@
             "about": {
                 "@id": "./"
             },
-            "conformsTo": {
-                "@id": "https://w3id.org/ro/crate/1.1"
-            }
+            "conformsTo": [
+                {
+                    "@id": "https://w3id.org/ro/crate/1.1"
+                },
+                {
+                    "@id": "https://w3id.org/workflowhub/workflow-ro-crate/1.0"
+                }
+            ]
         },
         {
             "@id": "predictions.cwl",
@@ -42,65 +47,65 @@
             ],
             "input": [
                 {
-                    "@id": "#d88b58a2-295c-4b67-83b9-2567ccdb71b9"
+                    "@id": "#fa691609-0414-4d18-8c8c-c03acd2122c7"
                 },
                 {
-                    "@id": "#e249a04b-b76e-403e-9e1d-24738fd9f273"
+                    "@id": "#c3492939-0518-4b42-8d36-9cd18453df71"
                 },
                 {
-                    "@id": "#a3340708-f775-45f7-99bf-e5cb8b95d715"
+                    "@id": "#35a6badf-9b9b-4057-8288-6114ab20c324"
                 },
                 {
-                    "@id": "#4464a310-2fff-4ebe-85c1-f17c1325dd7b"
+                    "@id": "#f72c0eb3-f939-44c9-9363-370063fd19de"
                 },
                 {
-                    "@id": "#a39f026d-041b-4f57-9a28-2f8c05051cc8"
+                    "@id": "#32137991-adfb-4928-a29f-1365e62b8200"
                 },
                 {
-                    "@id": "#9ed33ab1-1f53-4a5f-af4d-437912eb83a8"
+                    "@id": "#0425e87e-4ce0-40c9-89fe-eeefa1ccca7b"
                 },
                 {
-                    "@id": "#a408e7e5-d616-4a34-be04-0515f8d3acaa"
+                    "@id": "#f6c0b15a-85d6-4586-a5c5-fab304c31d2b"
                 },
                 {
-                    "@id": "#792aaa0d-30e0-47ec-a384-990c62d521aa"
+                    "@id": "#c49ad18c-f656-442c-926c-1a494c31300f"
                 },
                 {
-                    "@id": "#b287e5b5-3399-47fd-bbea-df93d1fd9583"
+                    "@id": "#48c6ba00-0192-4f46-b357-04e4bb2de9eb"
                 },
                 {
-                    "@id": "#5a86bf66-60ed-475e-a184-5a5f3e00251f"
+                    "@id": "#bbf5fb97-1287-4189-bd49-c71fd51796f1"
                 },
                 {
-                    "@id": "#41f51caf-1b7e-49e1-a029-6baef8591b10"
+                    "@id": "#a0a6ef94-d54d-4a72-8098-c4280753ab8b"
                 },
                 {
-                    "@id": "#d7fbcaeb-709a-4272-ac2a-4f2ded61f093"
+                    "@id": "#36e6fcc6-f4a5-4709-99ab-0dafb8b05c61"
                 },
                 {
-                    "@id": "#2f2168ba-524b-4afe-b4e1-3c7d0d2d7b45"
+                    "@id": "#46ffd3ef-318a-4a9c-ac4b-d938195d781d"
                 },
                 {
-                    "@id": "#71ffbf48-848c-4288-b123-ad3d093568f9"
+                    "@id": "#a8da2a6b-6d5b-457d-9b9f-a0a940b52bc3"
                 }
             ],
             "name": "Promort tissue and tumor prediction",
             "output": [
                 {
-                    "@id": "#9bf0095a-2b12-4384-9800-d4d333af45a8"
+                    "@id": "#1e2b5a3e-8128-4b82-8660-a7fd84ae6d38"
                 },
                 {
-                    "@id": "#7909197e-04cb-426d-a25a-b9be488a5b5f"
+                    "@id": "#5c56d714-1512-4190-97bd-fcbdeb4c3fe3"
                 }
             ],
             "programmingLanguage": {
-                "@id": "#cwl"
+                "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl"
             },
             "url": "https://github.com/crs4/deephealth-pipelines",
             "version": "0.1.0b1"
         },
         {
-            "@id": "#cwl",
+            "@id": "https://w3id.org/workflowhub/workflow-ro-crate#cwl",
             "@type": "ComputerLanguage",
             "alternateName": "CWL",
             "identifier": {
@@ -113,105 +118,105 @@
             "version": "v1.2"
         },
         {
-            "@id": "#d88b58a2-295c-4b67-83b9-2567ccdb71b9",
+            "@id": "#fa691609-0414-4d18-8c8c-c03acd2122c7",
             "@type": "FormalParameter",
             "additionalType": "File",
             "name": "slide",
             "value": "http://slide-repository:5000/slides/DHT00001-1.mrxs"
         },
         {
-            "@id": "#e249a04b-b76e-403e-9e1d-24738fd9f273",
+            "@id": "#c3492939-0518-4b42-8d36-9cd18453df71",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "mode",
             "value": "serial"
         },
         {
-            "@id": "#a3340708-f775-45f7-99bf-e5cb8b95d715",
+            "@id": "#35a6badf-9b9b-4057-8288-6114ab20c324",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-low-level",
             "value": 9
         },
         {
-            "@id": "#4464a310-2fff-4ebe-85c1-f17c1325dd7b",
+            "@id": "#f72c0eb3-f939-44c9-9363-370063fd19de",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tissue-low-label",
             "value": "tissue_low"
         },
         {
-            "@id": "#a39f026d-041b-4f57-9a28-2f8c05051cc8",
+            "@id": "#32137991-adfb-4928-a29f-1365e62b8200",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-high-level",
             "value": 8
         },
         {
-            "@id": "#9ed33ab1-1f53-4a5f-af4d-437912eb83a8",
+            "@id": "#0425e87e-4ce0-40c9-89fe-eeefa1ccca7b",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-low-chunk",
             "value": 256
         },
         {
-            "@id": "#a408e7e5-d616-4a34-be04-0515f8d3acaa",
+            "@id": "#f6c0b15a-85d6-4586-a5c5-fab304c31d2b",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tissue-high-label",
             "value": "tissue_high"
         },
         {
-            "@id": "#792aaa0d-30e0-47ec-a384-990c62d521aa",
+            "@id": "#c49ad18c-f656-442c-926c-1a494c31300f",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tissue-high-filter",
             "value": "tissue_low>1"
         },
         {
-            "@id": "#b287e5b5-3399-47fd-bbea-df93d1fd9583",
+            "@id": "#48c6ba00-0192-4f46-b357-04e4bb2de9eb",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-high-chunk",
             "value": 1536
         },
         {
-            "@id": "#5a86bf66-60ed-475e-a184-5a5f3e00251f",
+            "@id": "#bbf5fb97-1287-4189-bd49-c71fd51796f1",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tumor-chunk",
             "value": 1536
         },
         {
-            "@id": "#41f51caf-1b7e-49e1-a029-6baef8591b10",
+            "@id": "#a0a6ef94-d54d-4a72-8098-c4280753ab8b",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "gpu",
             "value": 0
         },
         {
-            "@id": "#d7fbcaeb-709a-4272-ac2a-4f2ded61f093",
+            "@id": "#36e6fcc6-f4a5-4709-99ab-0dafb8b05c61",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tumor-level",
             "value": 1
         },
         {
-            "@id": "#2f2168ba-524b-4afe-b4e1-3c7d0d2d7b45",
+            "@id": "#46ffd3ef-318a-4a9c-ac4b-d938195d781d",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tumor-label",
             "value": "tumor"
         },
         {
-            "@id": "#71ffbf48-848c-4288-b123-ad3d093568f9",
+            "@id": "#a8da2a6b-6d5b-457d-9b9f-a0a940b52bc3",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tumor-filter",
             "value": "tissue_low>1"
         },
         {
-            "@id": "#9bf0095a-2b12-4384-9800-d4d333af45a8",
+            "@id": "#1e2b5a3e-8128-4b82-8660-a7fd84ae6d38",
             "@type": "FormalParameter",
             "additionalType": "File",
             "name": "tissue",
@@ -223,7 +228,7 @@
             "contentSize": 4099
         },
         {
-            "@id": "#7909197e-04cb-426d-a25a-b9be488a5b5f",
+            "@id": "#5c56d714-1512-4190-97bd-fcbdeb4c3fe3",
             "@type": "FormalParameter",
             "additionalType": "File",
             "name": "tumor",

--- a/scripts/prov_crate/tests/expected_output/ro-crate-metadata.json
+++ b/scripts/prov_crate/tests/expected_output/ro-crate-metadata.json
@@ -4,7 +4,7 @@
         {
             "@id": "./",
             "@type": "Dataset",
-            "datePublished": "2022-02-15T10:41:32+00:00",
+            "datePublished": "2022-02-15T11:52:47+00:00",
             "hasPart": [
                 {
                     "@id": "predictions.cwl"
@@ -47,55 +47,55 @@
             ],
             "input": [
                 {
-                    "@id": "#fa691609-0414-4d18-8c8c-c03acd2122c7"
+                    "@id": "#dbff4668-4dff-4eea-9e2e-55729d90d0f3"
                 },
                 {
-                    "@id": "#c3492939-0518-4b42-8d36-9cd18453df71"
+                    "@id": "#fbc431d6-d7ec-4177-a7a9-45b502e0f8bd"
                 },
                 {
-                    "@id": "#35a6badf-9b9b-4057-8288-6114ab20c324"
+                    "@id": "#2e116ef6-0887-4a29-a1cc-ab08606bcf35"
                 },
                 {
-                    "@id": "#f72c0eb3-f939-44c9-9363-370063fd19de"
+                    "@id": "#67b1e67a-888d-4d23-91a8-863f11ac70fe"
                 },
                 {
-                    "@id": "#32137991-adfb-4928-a29f-1365e62b8200"
+                    "@id": "#4e520101-54e3-48cf-bcb1-f0114d7a18f7"
                 },
                 {
-                    "@id": "#0425e87e-4ce0-40c9-89fe-eeefa1ccca7b"
+                    "@id": "#40a102ad-1749-4542-868f-d1b1353e478f"
                 },
                 {
-                    "@id": "#f6c0b15a-85d6-4586-a5c5-fab304c31d2b"
+                    "@id": "#3fe70f9b-c167-40ac-af72-7d572f2c1100"
                 },
                 {
-                    "@id": "#c49ad18c-f656-442c-926c-1a494c31300f"
+                    "@id": "#4c720536-10cb-4fab-80e1-84c27009b346"
                 },
                 {
-                    "@id": "#48c6ba00-0192-4f46-b357-04e4bb2de9eb"
+                    "@id": "#ec05755a-c046-4385-9991-3fb219d55654"
                 },
                 {
-                    "@id": "#bbf5fb97-1287-4189-bd49-c71fd51796f1"
+                    "@id": "#acf5ed12-0236-4684-990d-bab67fbb3301"
                 },
                 {
-                    "@id": "#a0a6ef94-d54d-4a72-8098-c4280753ab8b"
+                    "@id": "#c5c47e8d-0385-4a33-ae4c-e6b79d993856"
                 },
                 {
-                    "@id": "#36e6fcc6-f4a5-4709-99ab-0dafb8b05c61"
+                    "@id": "#fe7ac610-f125-4b06-af61-281d82743971"
                 },
                 {
-                    "@id": "#46ffd3ef-318a-4a9c-ac4b-d938195d781d"
+                    "@id": "#75dd352a-6094-4db9-8a3e-903944c644e6"
                 },
                 {
-                    "@id": "#a8da2a6b-6d5b-457d-9b9f-a0a940b52bc3"
+                    "@id": "#b35fc14c-e665-45c2-9979-77959fd039df"
                 }
             ],
             "name": "Promort tissue and tumor prediction",
             "output": [
                 {
-                    "@id": "#1e2b5a3e-8128-4b82-8660-a7fd84ae6d38"
+                    "@id": "#5dc75cc6-1ca0-4b3c-bbc0-5cbee2bd5440"
                 },
                 {
-                    "@id": "#5c56d714-1512-4190-97bd-fcbdeb4c3fe3"
+                    "@id": "#57a0ae2b-13d0-471e-afcc-8f011e545665"
                 }
             ],
             "programmingLanguage": {
@@ -118,105 +118,105 @@
             "version": "v1.2"
         },
         {
-            "@id": "#fa691609-0414-4d18-8c8c-c03acd2122c7",
+            "@id": "#dbff4668-4dff-4eea-9e2e-55729d90d0f3",
             "@type": "FormalParameter",
             "additionalType": "File",
             "name": "slide",
             "value": "http://slide-repository:5000/slides/DHT00001-1.mrxs"
         },
         {
-            "@id": "#c3492939-0518-4b42-8d36-9cd18453df71",
+            "@id": "#fbc431d6-d7ec-4177-a7a9-45b502e0f8bd",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "mode",
             "value": "serial"
         },
         {
-            "@id": "#35a6badf-9b9b-4057-8288-6114ab20c324",
+            "@id": "#2e116ef6-0887-4a29-a1cc-ab08606bcf35",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-low-level",
             "value": 9
         },
         {
-            "@id": "#f72c0eb3-f939-44c9-9363-370063fd19de",
+            "@id": "#67b1e67a-888d-4d23-91a8-863f11ac70fe",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tissue-low-label",
             "value": "tissue_low"
         },
         {
-            "@id": "#32137991-adfb-4928-a29f-1365e62b8200",
+            "@id": "#4e520101-54e3-48cf-bcb1-f0114d7a18f7",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-high-level",
             "value": 8
         },
         {
-            "@id": "#0425e87e-4ce0-40c9-89fe-eeefa1ccca7b",
+            "@id": "#40a102ad-1749-4542-868f-d1b1353e478f",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-low-chunk",
             "value": 256
         },
         {
-            "@id": "#f6c0b15a-85d6-4586-a5c5-fab304c31d2b",
+            "@id": "#3fe70f9b-c167-40ac-af72-7d572f2c1100",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tissue-high-label",
             "value": "tissue_high"
         },
         {
-            "@id": "#c49ad18c-f656-442c-926c-1a494c31300f",
+            "@id": "#4c720536-10cb-4fab-80e1-84c27009b346",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tissue-high-filter",
             "value": "tissue_low>1"
         },
         {
-            "@id": "#48c6ba00-0192-4f46-b357-04e4bb2de9eb",
+            "@id": "#ec05755a-c046-4385-9991-3fb219d55654",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-high-chunk",
             "value": 1536
         },
         {
-            "@id": "#bbf5fb97-1287-4189-bd49-c71fd51796f1",
+            "@id": "#acf5ed12-0236-4684-990d-bab67fbb3301",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tumor-chunk",
             "value": 1536
         },
         {
-            "@id": "#a0a6ef94-d54d-4a72-8098-c4280753ab8b",
+            "@id": "#c5c47e8d-0385-4a33-ae4c-e6b79d993856",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "gpu",
             "value": 0
         },
         {
-            "@id": "#36e6fcc6-f4a5-4709-99ab-0dafb8b05c61",
+            "@id": "#fe7ac610-f125-4b06-af61-281d82743971",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tumor-level",
             "value": 1
         },
         {
-            "@id": "#46ffd3ef-318a-4a9c-ac4b-d938195d781d",
+            "@id": "#75dd352a-6094-4db9-8a3e-903944c644e6",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tumor-label",
             "value": "tumor"
         },
         {
-            "@id": "#a8da2a6b-6d5b-457d-9b9f-a0a940b52bc3",
+            "@id": "#b35fc14c-e665-45c2-9979-77959fd039df",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tumor-filter",
             "value": "tissue_low>1"
         },
         {
-            "@id": "#1e2b5a3e-8128-4b82-8660-a7fd84ae6d38",
+            "@id": "#5dc75cc6-1ca0-4b3c-bbc0-5cbee2bd5440",
             "@type": "FormalParameter",
             "additionalType": "File",
             "name": "tissue",
@@ -228,7 +228,7 @@
             "contentSize": 4099
         },
         {
-            "@id": "#5c56d714-1512-4190-97bd-fcbdeb4c3fe3",
+            "@id": "#57a0ae2b-13d0-471e-afcc-8f011e545665",
             "@type": "FormalParameter",
             "additionalType": "File",
             "name": "tumor",
@@ -238,6 +238,68 @@
             "@id": "tumor.zip",
             "@type": "File",
             "contentSize": 70100
+        },
+        {
+            "@id": "#ddc1a4ae-4833-4302-aa1a-a56ccfc0e4ab",
+            "@type": "CreateAction",
+            "endTime": "2021-06-29T16:09:45.814390+00:00",
+            "instrument": {
+                "@id": "predictions.cwl"
+            },
+            "name": "Promort prediction run on 2021-06-29T16:07:14.873427+00:00",
+            "object": [
+                {
+                    "@id": "#dbff4668-4dff-4eea-9e2e-55729d90d0f3"
+                },
+                {
+                    "@id": "#fbc431d6-d7ec-4177-a7a9-45b502e0f8bd"
+                },
+                {
+                    "@id": "#2e116ef6-0887-4a29-a1cc-ab08606bcf35"
+                },
+                {
+                    "@id": "#67b1e67a-888d-4d23-91a8-863f11ac70fe"
+                },
+                {
+                    "@id": "#4e520101-54e3-48cf-bcb1-f0114d7a18f7"
+                },
+                {
+                    "@id": "#40a102ad-1749-4542-868f-d1b1353e478f"
+                },
+                {
+                    "@id": "#3fe70f9b-c167-40ac-af72-7d572f2c1100"
+                },
+                {
+                    "@id": "#4c720536-10cb-4fab-80e1-84c27009b346"
+                },
+                {
+                    "@id": "#ec05755a-c046-4385-9991-3fb219d55654"
+                },
+                {
+                    "@id": "#acf5ed12-0236-4684-990d-bab67fbb3301"
+                },
+                {
+                    "@id": "#c5c47e8d-0385-4a33-ae4c-e6b79d993856"
+                },
+                {
+                    "@id": "#fe7ac610-f125-4b06-af61-281d82743971"
+                },
+                {
+                    "@id": "#75dd352a-6094-4db9-8a3e-903944c644e6"
+                },
+                {
+                    "@id": "#b35fc14c-e665-45c2-9979-77959fd039df"
+                }
+            ],
+            "result": [
+                {
+                    "@id": "#5dc75cc6-1ca0-4b3c-bbc0-5cbee2bd5440"
+                },
+                {
+                    "@id": "#57a0ae2b-13d0-471e-afcc-8f011e545665"
+                }
+            ],
+            "startTime": "2021-06-29T16:07:14.873427+00:00"
         }
     ]
 }

--- a/scripts/prov_crate/tests/expected_output/ro-crate-metadata.json
+++ b/scripts/prov_crate/tests/expected_output/ro-crate-metadata.json
@@ -4,7 +4,7 @@
         {
             "@id": "./",
             "@type": "Dataset",
-            "datePublished": "2022-02-15T16:41:01+00:00",
+            "datePublished": "2022-02-16T10:47:17+00:00",
             "hasPart": [
                 {
                     "@id": "predictions.cwl"
@@ -47,55 +47,55 @@
             ],
             "input": [
                 {
-                    "@id": "#780aa526-eeb4-4d3b-ad8b-14da682f80af"
+                    "@id": "#param-slide"
                 },
                 {
-                    "@id": "#a29f0b1b-15a3-4976-818f-fa83a6c46b9a"
+                    "@id": "#param-mode"
                 },
                 {
-                    "@id": "#18f6d669-91ca-4f09-a053-205a65d4a4e9"
+                    "@id": "#param-tissue-low-level"
                 },
                 {
-                    "@id": "#0a43ee42-b2ff-408e-8cf5-20dce6f8f3af"
+                    "@id": "#param-tissue-low-label"
                 },
                 {
-                    "@id": "#80cbf6a2-64f9-4d62-be4e-1592760d1a1c"
+                    "@id": "#param-tissue-high-level"
                 },
                 {
-                    "@id": "#1880b103-7477-4e60-999a-c83923dc17f7"
+                    "@id": "#param-tissue-low-chunk"
                 },
                 {
-                    "@id": "#d93f438e-7214-4c80-ba21-3244d6de30c4"
+                    "@id": "#param-tissue-high-label"
                 },
                 {
-                    "@id": "#777955e6-1301-4652-aac7-f8acf65e51e0"
+                    "@id": "#param-tissue-high-filter"
                 },
                 {
-                    "@id": "#d1585ffa-f5db-4ae1-980f-389504ad60fe"
+                    "@id": "#param-tissue-high-chunk"
                 },
                 {
-                    "@id": "#50c4d970-3a82-41eb-8e02-22c5831fc882"
+                    "@id": "#param-tumor-chunk"
                 },
                 {
-                    "@id": "#160c9d45-6cc3-4d46-ba62-a2bf033ff67e"
+                    "@id": "#param-gpu"
                 },
                 {
-                    "@id": "#ba92690c-9abf-4384-a2a7-07be0107dbcb"
+                    "@id": "#param-tumor-level"
                 },
                 {
-                    "@id": "#4719501a-2a3d-47c9-9b37-eb21bc637e88"
+                    "@id": "#param-tumor-label"
                 },
                 {
-                    "@id": "#215ab585-6fae-4df0-bea1-f7c9dcd25d94"
+                    "@id": "#param-tumor-filter"
                 }
             ],
             "name": "Promort tissue and tumor prediction",
             "output": [
                 {
-                    "@id": "#b192cffb-6938-4efa-afad-fc364a38089e"
+                    "@id": "#param-tissue"
                 },
                 {
-                    "@id": "#a9de171d-411f-437c-8b59-1f6ede53361e"
+                    "@id": "#param-tumor"
                 }
             ],
             "programmingLanguage": {
@@ -118,7 +118,7 @@
             "version": "v1.2"
         },
         {
-            "@id": "#4c2af0c7-3104-4ebe-8138-91066f4a965c",
+            "@id": "#635a03f9-1c5a-4aaf-8d20-b8c7e2c50dd6",
             "@type": "CreateAction",
             "endTime": "2021-06-29T16:09:45.814390+00:00",
             "instrument": {
@@ -127,46 +127,46 @@
             "name": "Promort prediction run on 2021-06-29T16:07:14.873427+00:00",
             "object": [
                 {
-                    "@id": "#e7863b44-bb14-4e45-bb2d-cd6d7a17d8dc"
+                    "@id": "#pv-slide"
                 },
                 {
-                    "@id": "#6d7f2769-9175-4ccc-87c6-de1b996235c6"
+                    "@id": "#pv-mode"
                 },
                 {
-                    "@id": "#5743d24f-e570-48e5-a135-a4d405743daa"
+                    "@id": "#pv-tissue-low-level"
                 },
                 {
-                    "@id": "#73bec44c-7e7e-4ae6-8983-be0d08a8e658"
+                    "@id": "#pv-tissue-low-label"
                 },
                 {
-                    "@id": "#0bab8d3d-8f47-4ef8-9892-5856abac2cbf"
+                    "@id": "#pv-tissue-high-level"
                 },
                 {
-                    "@id": "#7a903041-7711-4eef-9bae-20b1199e348e"
+                    "@id": "#pv-tissue-low-chunk"
                 },
                 {
-                    "@id": "#9680509a-1362-4cb8-abaa-c2ca8a55d775"
+                    "@id": "#pv-tissue-high-label"
                 },
                 {
-                    "@id": "#b86d6209-2be6-4912-83f9-bdc07b303e66"
+                    "@id": "#pv-tissue-high-filter"
                 },
                 {
-                    "@id": "#b2316942-6fc3-4950-bbcf-04c8bcb51ae2"
+                    "@id": "#pv-tissue-high-chunk"
                 },
                 {
-                    "@id": "#3d9580a3-5f6d-425d-a1ba-e566d2f9e6f7"
+                    "@id": "#pv-tumor-chunk"
                 },
                 {
-                    "@id": "#ce94ae6d-c5dc-4e88-b008-855dc0287de5"
+                    "@id": "#pv-gpu"
                 },
                 {
-                    "@id": "#5234adbf-1dc2-44d6-a978-4e332ed1a93f"
+                    "@id": "#pv-tumor-level"
                 },
                 {
-                    "@id": "#6968a1c2-5364-4ad9-9379-edf90f557520"
+                    "@id": "#pv-tumor-label"
                 },
                 {
-                    "@id": "#207fc4b4-a11e-42a4-bc49-92a668c9038f"
+                    "@id": "#pv-tumor-filter"
                 }
             ],
             "result": [
@@ -180,189 +180,189 @@
             "startTime": "2021-06-29T16:07:14.873427+00:00"
         },
         {
-            "@id": "#780aa526-eeb4-4d3b-ad8b-14da682f80af",
+            "@id": "#param-slide",
             "@type": "FormalParameter",
             "additionalType": "File",
             "name": "slide"
         },
         {
-            "@id": "#e7863b44-bb14-4e45-bb2d-cd6d7a17d8dc",
+            "@id": "#pv-slide",
             "@type": "PropertyValue",
             "additionalType": "File",
             "name": "slide",
             "value": "http://slide-repository:5000/slides/DHT00001-1.mrxs"
         },
         {
-            "@id": "#a29f0b1b-15a3-4976-818f-fa83a6c46b9a",
+            "@id": "#param-mode",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "mode"
         },
         {
-            "@id": "#6d7f2769-9175-4ccc-87c6-de1b996235c6",
+            "@id": "#pv-mode",
             "@type": "PropertyValue",
             "additionalType": "Text",
             "name": "mode",
             "value": "serial"
         },
         {
-            "@id": "#18f6d669-91ca-4f09-a053-205a65d4a4e9",
+            "@id": "#param-tissue-low-level",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-low-level"
         },
         {
-            "@id": "#5743d24f-e570-48e5-a135-a4d405743daa",
+            "@id": "#pv-tissue-low-level",
             "@type": "PropertyValue",
             "additionalType": "Number",
             "name": "tissue-low-level",
             "value": 9
         },
         {
-            "@id": "#0a43ee42-b2ff-408e-8cf5-20dce6f8f3af",
+            "@id": "#param-tissue-low-label",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tissue-low-label"
         },
         {
-            "@id": "#73bec44c-7e7e-4ae6-8983-be0d08a8e658",
+            "@id": "#pv-tissue-low-label",
             "@type": "PropertyValue",
             "additionalType": "Text",
             "name": "tissue-low-label",
             "value": "tissue_low"
         },
         {
-            "@id": "#80cbf6a2-64f9-4d62-be4e-1592760d1a1c",
+            "@id": "#param-tissue-high-level",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-high-level"
         },
         {
-            "@id": "#0bab8d3d-8f47-4ef8-9892-5856abac2cbf",
+            "@id": "#pv-tissue-high-level",
             "@type": "PropertyValue",
             "additionalType": "Number",
             "name": "tissue-high-level",
             "value": 8
         },
         {
-            "@id": "#1880b103-7477-4e60-999a-c83923dc17f7",
+            "@id": "#param-tissue-low-chunk",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-low-chunk"
         },
         {
-            "@id": "#7a903041-7711-4eef-9bae-20b1199e348e",
+            "@id": "#pv-tissue-low-chunk",
             "@type": "PropertyValue",
             "additionalType": "Number",
             "name": "tissue-low-chunk",
             "value": 256
         },
         {
-            "@id": "#d93f438e-7214-4c80-ba21-3244d6de30c4",
+            "@id": "#param-tissue-high-label",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tissue-high-label"
         },
         {
-            "@id": "#9680509a-1362-4cb8-abaa-c2ca8a55d775",
+            "@id": "#pv-tissue-high-label",
             "@type": "PropertyValue",
             "additionalType": "Text",
             "name": "tissue-high-label",
             "value": "tissue_high"
         },
         {
-            "@id": "#777955e6-1301-4652-aac7-f8acf65e51e0",
+            "@id": "#param-tissue-high-filter",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tissue-high-filter"
         },
         {
-            "@id": "#b86d6209-2be6-4912-83f9-bdc07b303e66",
+            "@id": "#pv-tissue-high-filter",
             "@type": "PropertyValue",
             "additionalType": "Text",
             "name": "tissue-high-filter",
             "value": "tissue_low>1"
         },
         {
-            "@id": "#d1585ffa-f5db-4ae1-980f-389504ad60fe",
+            "@id": "#param-tissue-high-chunk",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tissue-high-chunk"
         },
         {
-            "@id": "#b2316942-6fc3-4950-bbcf-04c8bcb51ae2",
+            "@id": "#pv-tissue-high-chunk",
             "@type": "PropertyValue",
             "additionalType": "Number",
             "name": "tissue-high-chunk",
             "value": 1536
         },
         {
-            "@id": "#50c4d970-3a82-41eb-8e02-22c5831fc882",
+            "@id": "#param-tumor-chunk",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tumor-chunk"
         },
         {
-            "@id": "#3d9580a3-5f6d-425d-a1ba-e566d2f9e6f7",
+            "@id": "#pv-tumor-chunk",
             "@type": "PropertyValue",
             "additionalType": "Number",
             "name": "tumor-chunk",
             "value": 1536
         },
         {
-            "@id": "#160c9d45-6cc3-4d46-ba62-a2bf033ff67e",
+            "@id": "#param-gpu",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "gpu"
         },
         {
-            "@id": "#ce94ae6d-c5dc-4e88-b008-855dc0287de5",
+            "@id": "#pv-gpu",
             "@type": "PropertyValue",
             "additionalType": "Number",
             "name": "gpu",
             "value": 0
         },
         {
-            "@id": "#ba92690c-9abf-4384-a2a7-07be0107dbcb",
+            "@id": "#param-tumor-level",
             "@type": "FormalParameter",
             "additionalType": "Number",
             "name": "tumor-level"
         },
         {
-            "@id": "#5234adbf-1dc2-44d6-a978-4e332ed1a93f",
+            "@id": "#pv-tumor-level",
             "@type": "PropertyValue",
             "additionalType": "Number",
             "name": "tumor-level",
             "value": 1
         },
         {
-            "@id": "#4719501a-2a3d-47c9-9b37-eb21bc637e88",
+            "@id": "#param-tumor-label",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tumor-label"
         },
         {
-            "@id": "#6968a1c2-5364-4ad9-9379-edf90f557520",
+            "@id": "#pv-tumor-label",
             "@type": "PropertyValue",
             "additionalType": "Text",
             "name": "tumor-label",
             "value": "tumor"
         },
         {
-            "@id": "#215ab585-6fae-4df0-bea1-f7c9dcd25d94",
+            "@id": "#param-tumor-filter",
             "@type": "FormalParameter",
             "additionalType": "Text",
             "name": "tumor-filter"
         },
         {
-            "@id": "#207fc4b4-a11e-42a4-bc49-92a668c9038f",
+            "@id": "#pv-tumor-filter",
             "@type": "PropertyValue",
             "additionalType": "Text",
             "name": "tumor-filter",
             "value": "tissue_low>1"
         },
         {
-            "@id": "#b192cffb-6938-4efa-afad-fc364a38089e",
+            "@id": "#param-tissue",
             "@type": "FormalParameter",
             "additionalType": "File",
             "name": "tissue"
@@ -373,7 +373,7 @@
             "contentSize": 4099
         },
         {
-            "@id": "#a9de171d-411f-437c-8b59-1f6ede53361e",
+            "@id": "#param-tumor",
             "@type": "FormalParameter",
             "additionalType": "File",
             "name": "tumor"

--- a/scripts/prov_crate/tests/expected_output/ro-crate-metadata.json
+++ b/scripts/prov_crate/tests/expected_output/ro-crate-metadata.json
@@ -4,7 +4,7 @@
         {
             "@id": "./",
             "@type": "Dataset",
-            "datePublished": "2022-02-16T10:47:17+00:00",
+            "datePublished": "2022-02-16T11:07:48+00:00",
             "hasPart": [
                 {
                     "@id": "predictions.cwl"
@@ -118,7 +118,7 @@
             "version": "v1.2"
         },
         {
-            "@id": "#635a03f9-1c5a-4aaf-8d20-b8c7e2c50dd6",
+            "@id": "#0762bd43-6703-4255-ab0a-c85435039a42",
             "@type": "CreateAction",
             "endTime": "2021-06-29T16:09:45.814390+00:00",
             "instrument": {
@@ -182,13 +182,13 @@
         {
             "@id": "#param-slide",
             "@type": "FormalParameter",
-            "additionalType": "File",
+            "additionalType": "https://openslide.org/formats/mirax/",
             "name": "slide"
         },
         {
             "@id": "#pv-slide",
             "@type": "PropertyValue",
-            "additionalType": "File",
+            "additionalType": "https://openslide.org/formats/mirax/",
             "name": "slide",
             "value": "http://slide-repository:5000/slides/DHT00001-1.mrxs"
         },
@@ -208,13 +208,13 @@
         {
             "@id": "#param-tissue-low-level",
             "@type": "FormalParameter",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tissue-low-level"
         },
         {
             "@id": "#pv-tissue-low-level",
             "@type": "PropertyValue",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tissue-low-level",
             "value": 9
         },
@@ -234,26 +234,26 @@
         {
             "@id": "#param-tissue-high-level",
             "@type": "FormalParameter",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tissue-high-level"
         },
         {
             "@id": "#pv-tissue-high-level",
             "@type": "PropertyValue",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tissue-high-level",
             "value": 8
         },
         {
             "@id": "#param-tissue-low-chunk",
             "@type": "FormalParameter",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tissue-low-chunk"
         },
         {
             "@id": "#pv-tissue-low-chunk",
             "@type": "PropertyValue",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tissue-low-chunk",
             "value": 256
         },
@@ -286,52 +286,52 @@
         {
             "@id": "#param-tissue-high-chunk",
             "@type": "FormalParameter",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tissue-high-chunk"
         },
         {
             "@id": "#pv-tissue-high-chunk",
             "@type": "PropertyValue",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tissue-high-chunk",
             "value": 1536
         },
         {
             "@id": "#param-tumor-chunk",
             "@type": "FormalParameter",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tumor-chunk"
         },
         {
             "@id": "#pv-tumor-chunk",
             "@type": "PropertyValue",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tumor-chunk",
             "value": 1536
         },
         {
             "@id": "#param-gpu",
             "@type": "FormalParameter",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "gpu"
         },
         {
             "@id": "#pv-gpu",
             "@type": "PropertyValue",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "gpu",
             "value": 0
         },
         {
             "@id": "#param-tumor-level",
             "@type": "FormalParameter",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tumor-level"
         },
         {
             "@id": "#pv-tumor-level",
             "@type": "PropertyValue",
-            "additionalType": "Number",
+            "additionalType": "Integer",
             "name": "tumor-level",
             "value": 1
         },
@@ -364,7 +364,7 @@
         {
             "@id": "#param-tissue",
             "@type": "FormalParameter",
-            "additionalType": "File",
+            "additionalType": "https://zarr.readthedocs.io/en/stable/spec/v2.html",
             "name": "tissue"
         },
         {
@@ -375,7 +375,7 @@
         {
             "@id": "#param-tumor",
             "@type": "FormalParameter",
-            "additionalType": "File",
+            "additionalType": "https://zarr.readthedocs.io/en/stable/spec/v2.html",
             "name": "tumor"
         },
         {

--- a/scripts/prov_crate/tests/expected_output/ro-crate-metadata.json
+++ b/scripts/prov_crate/tests/expected_output/ro-crate-metadata.json
@@ -4,7 +4,7 @@
         {
             "@id": "./",
             "@type": "Dataset",
-            "datePublished": "2022-02-15T11:52:47+00:00",
+            "datePublished": "2022-02-15T16:41:01+00:00",
             "hasPart": [
                 {
                     "@id": "predictions.cwl"
@@ -47,55 +47,55 @@
             ],
             "input": [
                 {
-                    "@id": "#dbff4668-4dff-4eea-9e2e-55729d90d0f3"
+                    "@id": "#780aa526-eeb4-4d3b-ad8b-14da682f80af"
                 },
                 {
-                    "@id": "#fbc431d6-d7ec-4177-a7a9-45b502e0f8bd"
+                    "@id": "#a29f0b1b-15a3-4976-818f-fa83a6c46b9a"
                 },
                 {
-                    "@id": "#2e116ef6-0887-4a29-a1cc-ab08606bcf35"
+                    "@id": "#18f6d669-91ca-4f09-a053-205a65d4a4e9"
                 },
                 {
-                    "@id": "#67b1e67a-888d-4d23-91a8-863f11ac70fe"
+                    "@id": "#0a43ee42-b2ff-408e-8cf5-20dce6f8f3af"
                 },
                 {
-                    "@id": "#4e520101-54e3-48cf-bcb1-f0114d7a18f7"
+                    "@id": "#80cbf6a2-64f9-4d62-be4e-1592760d1a1c"
                 },
                 {
-                    "@id": "#40a102ad-1749-4542-868f-d1b1353e478f"
+                    "@id": "#1880b103-7477-4e60-999a-c83923dc17f7"
                 },
                 {
-                    "@id": "#3fe70f9b-c167-40ac-af72-7d572f2c1100"
+                    "@id": "#d93f438e-7214-4c80-ba21-3244d6de30c4"
                 },
                 {
-                    "@id": "#4c720536-10cb-4fab-80e1-84c27009b346"
+                    "@id": "#777955e6-1301-4652-aac7-f8acf65e51e0"
                 },
                 {
-                    "@id": "#ec05755a-c046-4385-9991-3fb219d55654"
+                    "@id": "#d1585ffa-f5db-4ae1-980f-389504ad60fe"
                 },
                 {
-                    "@id": "#acf5ed12-0236-4684-990d-bab67fbb3301"
+                    "@id": "#50c4d970-3a82-41eb-8e02-22c5831fc882"
                 },
                 {
-                    "@id": "#c5c47e8d-0385-4a33-ae4c-e6b79d993856"
+                    "@id": "#160c9d45-6cc3-4d46-ba62-a2bf033ff67e"
                 },
                 {
-                    "@id": "#fe7ac610-f125-4b06-af61-281d82743971"
+                    "@id": "#ba92690c-9abf-4384-a2a7-07be0107dbcb"
                 },
                 {
-                    "@id": "#75dd352a-6094-4db9-8a3e-903944c644e6"
+                    "@id": "#4719501a-2a3d-47c9-9b37-eb21bc637e88"
                 },
                 {
-                    "@id": "#b35fc14c-e665-45c2-9979-77959fd039df"
+                    "@id": "#215ab585-6fae-4df0-bea1-f7c9dcd25d94"
                 }
             ],
             "name": "Promort tissue and tumor prediction",
             "output": [
                 {
-                    "@id": "#5dc75cc6-1ca0-4b3c-bbc0-5cbee2bd5440"
+                    "@id": "#b192cffb-6938-4efa-afad-fc364a38089e"
                 },
                 {
-                    "@id": "#57a0ae2b-13d0-471e-afcc-8f011e545665"
+                    "@id": "#a9de171d-411f-437c-8b59-1f6ede53361e"
                 }
             ],
             "programmingLanguage": {
@@ -118,129 +118,7 @@
             "version": "v1.2"
         },
         {
-            "@id": "#dbff4668-4dff-4eea-9e2e-55729d90d0f3",
-            "@type": "FormalParameter",
-            "additionalType": "File",
-            "name": "slide",
-            "value": "http://slide-repository:5000/slides/DHT00001-1.mrxs"
-        },
-        {
-            "@id": "#fbc431d6-d7ec-4177-a7a9-45b502e0f8bd",
-            "@type": "FormalParameter",
-            "additionalType": "Text",
-            "name": "mode",
-            "value": "serial"
-        },
-        {
-            "@id": "#2e116ef6-0887-4a29-a1cc-ab08606bcf35",
-            "@type": "FormalParameter",
-            "additionalType": "Number",
-            "name": "tissue-low-level",
-            "value": 9
-        },
-        {
-            "@id": "#67b1e67a-888d-4d23-91a8-863f11ac70fe",
-            "@type": "FormalParameter",
-            "additionalType": "Text",
-            "name": "tissue-low-label",
-            "value": "tissue_low"
-        },
-        {
-            "@id": "#4e520101-54e3-48cf-bcb1-f0114d7a18f7",
-            "@type": "FormalParameter",
-            "additionalType": "Number",
-            "name": "tissue-high-level",
-            "value": 8
-        },
-        {
-            "@id": "#40a102ad-1749-4542-868f-d1b1353e478f",
-            "@type": "FormalParameter",
-            "additionalType": "Number",
-            "name": "tissue-low-chunk",
-            "value": 256
-        },
-        {
-            "@id": "#3fe70f9b-c167-40ac-af72-7d572f2c1100",
-            "@type": "FormalParameter",
-            "additionalType": "Text",
-            "name": "tissue-high-label",
-            "value": "tissue_high"
-        },
-        {
-            "@id": "#4c720536-10cb-4fab-80e1-84c27009b346",
-            "@type": "FormalParameter",
-            "additionalType": "Text",
-            "name": "tissue-high-filter",
-            "value": "tissue_low>1"
-        },
-        {
-            "@id": "#ec05755a-c046-4385-9991-3fb219d55654",
-            "@type": "FormalParameter",
-            "additionalType": "Number",
-            "name": "tissue-high-chunk",
-            "value": 1536
-        },
-        {
-            "@id": "#acf5ed12-0236-4684-990d-bab67fbb3301",
-            "@type": "FormalParameter",
-            "additionalType": "Number",
-            "name": "tumor-chunk",
-            "value": 1536
-        },
-        {
-            "@id": "#c5c47e8d-0385-4a33-ae4c-e6b79d993856",
-            "@type": "FormalParameter",
-            "additionalType": "Number",
-            "name": "gpu",
-            "value": 0
-        },
-        {
-            "@id": "#fe7ac610-f125-4b06-af61-281d82743971",
-            "@type": "FormalParameter",
-            "additionalType": "Number",
-            "name": "tumor-level",
-            "value": 1
-        },
-        {
-            "@id": "#75dd352a-6094-4db9-8a3e-903944c644e6",
-            "@type": "FormalParameter",
-            "additionalType": "Text",
-            "name": "tumor-label",
-            "value": "tumor"
-        },
-        {
-            "@id": "#b35fc14c-e665-45c2-9979-77959fd039df",
-            "@type": "FormalParameter",
-            "additionalType": "Text",
-            "name": "tumor-filter",
-            "value": "tissue_low>1"
-        },
-        {
-            "@id": "#5dc75cc6-1ca0-4b3c-bbc0-5cbee2bd5440",
-            "@type": "FormalParameter",
-            "additionalType": "File",
-            "name": "tissue",
-            "value": "tissue_high.zip"
-        },
-        {
-            "@id": "tissue_high.zip",
-            "@type": "File",
-            "contentSize": 4099
-        },
-        {
-            "@id": "#57a0ae2b-13d0-471e-afcc-8f011e545665",
-            "@type": "FormalParameter",
-            "additionalType": "File",
-            "name": "tumor",
-            "value": "tumor.zip"
-        },
-        {
-            "@id": "tumor.zip",
-            "@type": "File",
-            "contentSize": 70100
-        },
-        {
-            "@id": "#ddc1a4ae-4833-4302-aa1a-a56ccfc0e4ab",
+            "@id": "#4c2af0c7-3104-4ebe-8138-91066f4a965c",
             "@type": "CreateAction",
             "endTime": "2021-06-29T16:09:45.814390+00:00",
             "instrument": {
@@ -249,57 +127,261 @@
             "name": "Promort prediction run on 2021-06-29T16:07:14.873427+00:00",
             "object": [
                 {
-                    "@id": "#dbff4668-4dff-4eea-9e2e-55729d90d0f3"
+                    "@id": "#e7863b44-bb14-4e45-bb2d-cd6d7a17d8dc"
                 },
                 {
-                    "@id": "#fbc431d6-d7ec-4177-a7a9-45b502e0f8bd"
+                    "@id": "#6d7f2769-9175-4ccc-87c6-de1b996235c6"
                 },
                 {
-                    "@id": "#2e116ef6-0887-4a29-a1cc-ab08606bcf35"
+                    "@id": "#5743d24f-e570-48e5-a135-a4d405743daa"
                 },
                 {
-                    "@id": "#67b1e67a-888d-4d23-91a8-863f11ac70fe"
+                    "@id": "#73bec44c-7e7e-4ae6-8983-be0d08a8e658"
                 },
                 {
-                    "@id": "#4e520101-54e3-48cf-bcb1-f0114d7a18f7"
+                    "@id": "#0bab8d3d-8f47-4ef8-9892-5856abac2cbf"
                 },
                 {
-                    "@id": "#40a102ad-1749-4542-868f-d1b1353e478f"
+                    "@id": "#7a903041-7711-4eef-9bae-20b1199e348e"
                 },
                 {
-                    "@id": "#3fe70f9b-c167-40ac-af72-7d572f2c1100"
+                    "@id": "#9680509a-1362-4cb8-abaa-c2ca8a55d775"
                 },
                 {
-                    "@id": "#4c720536-10cb-4fab-80e1-84c27009b346"
+                    "@id": "#b86d6209-2be6-4912-83f9-bdc07b303e66"
                 },
                 {
-                    "@id": "#ec05755a-c046-4385-9991-3fb219d55654"
+                    "@id": "#b2316942-6fc3-4950-bbcf-04c8bcb51ae2"
                 },
                 {
-                    "@id": "#acf5ed12-0236-4684-990d-bab67fbb3301"
+                    "@id": "#3d9580a3-5f6d-425d-a1ba-e566d2f9e6f7"
                 },
                 {
-                    "@id": "#c5c47e8d-0385-4a33-ae4c-e6b79d993856"
+                    "@id": "#ce94ae6d-c5dc-4e88-b008-855dc0287de5"
                 },
                 {
-                    "@id": "#fe7ac610-f125-4b06-af61-281d82743971"
+                    "@id": "#5234adbf-1dc2-44d6-a978-4e332ed1a93f"
                 },
                 {
-                    "@id": "#75dd352a-6094-4db9-8a3e-903944c644e6"
+                    "@id": "#6968a1c2-5364-4ad9-9379-edf90f557520"
                 },
                 {
-                    "@id": "#b35fc14c-e665-45c2-9979-77959fd039df"
+                    "@id": "#207fc4b4-a11e-42a4-bc49-92a668c9038f"
                 }
             ],
             "result": [
                 {
-                    "@id": "#5dc75cc6-1ca0-4b3c-bbc0-5cbee2bd5440"
+                    "@id": "tissue_high.zip"
                 },
                 {
-                    "@id": "#57a0ae2b-13d0-471e-afcc-8f011e545665"
+                    "@id": "tumor.zip"
                 }
             ],
             "startTime": "2021-06-29T16:07:14.873427+00:00"
+        },
+        {
+            "@id": "#780aa526-eeb4-4d3b-ad8b-14da682f80af",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "slide"
+        },
+        {
+            "@id": "#e7863b44-bb14-4e45-bb2d-cd6d7a17d8dc",
+            "@type": "PropertyValue",
+            "additionalType": "File",
+            "name": "slide",
+            "value": "http://slide-repository:5000/slides/DHT00001-1.mrxs"
+        },
+        {
+            "@id": "#a29f0b1b-15a3-4976-818f-fa83a6c46b9a",
+            "@type": "FormalParameter",
+            "additionalType": "Text",
+            "name": "mode"
+        },
+        {
+            "@id": "#6d7f2769-9175-4ccc-87c6-de1b996235c6",
+            "@type": "PropertyValue",
+            "additionalType": "Text",
+            "name": "mode",
+            "value": "serial"
+        },
+        {
+            "@id": "#18f6d669-91ca-4f09-a053-205a65d4a4e9",
+            "@type": "FormalParameter",
+            "additionalType": "Number",
+            "name": "tissue-low-level"
+        },
+        {
+            "@id": "#5743d24f-e570-48e5-a135-a4d405743daa",
+            "@type": "PropertyValue",
+            "additionalType": "Number",
+            "name": "tissue-low-level",
+            "value": 9
+        },
+        {
+            "@id": "#0a43ee42-b2ff-408e-8cf5-20dce6f8f3af",
+            "@type": "FormalParameter",
+            "additionalType": "Text",
+            "name": "tissue-low-label"
+        },
+        {
+            "@id": "#73bec44c-7e7e-4ae6-8983-be0d08a8e658",
+            "@type": "PropertyValue",
+            "additionalType": "Text",
+            "name": "tissue-low-label",
+            "value": "tissue_low"
+        },
+        {
+            "@id": "#80cbf6a2-64f9-4d62-be4e-1592760d1a1c",
+            "@type": "FormalParameter",
+            "additionalType": "Number",
+            "name": "tissue-high-level"
+        },
+        {
+            "@id": "#0bab8d3d-8f47-4ef8-9892-5856abac2cbf",
+            "@type": "PropertyValue",
+            "additionalType": "Number",
+            "name": "tissue-high-level",
+            "value": 8
+        },
+        {
+            "@id": "#1880b103-7477-4e60-999a-c83923dc17f7",
+            "@type": "FormalParameter",
+            "additionalType": "Number",
+            "name": "tissue-low-chunk"
+        },
+        {
+            "@id": "#7a903041-7711-4eef-9bae-20b1199e348e",
+            "@type": "PropertyValue",
+            "additionalType": "Number",
+            "name": "tissue-low-chunk",
+            "value": 256
+        },
+        {
+            "@id": "#d93f438e-7214-4c80-ba21-3244d6de30c4",
+            "@type": "FormalParameter",
+            "additionalType": "Text",
+            "name": "tissue-high-label"
+        },
+        {
+            "@id": "#9680509a-1362-4cb8-abaa-c2ca8a55d775",
+            "@type": "PropertyValue",
+            "additionalType": "Text",
+            "name": "tissue-high-label",
+            "value": "tissue_high"
+        },
+        {
+            "@id": "#777955e6-1301-4652-aac7-f8acf65e51e0",
+            "@type": "FormalParameter",
+            "additionalType": "Text",
+            "name": "tissue-high-filter"
+        },
+        {
+            "@id": "#b86d6209-2be6-4912-83f9-bdc07b303e66",
+            "@type": "PropertyValue",
+            "additionalType": "Text",
+            "name": "tissue-high-filter",
+            "value": "tissue_low>1"
+        },
+        {
+            "@id": "#d1585ffa-f5db-4ae1-980f-389504ad60fe",
+            "@type": "FormalParameter",
+            "additionalType": "Number",
+            "name": "tissue-high-chunk"
+        },
+        {
+            "@id": "#b2316942-6fc3-4950-bbcf-04c8bcb51ae2",
+            "@type": "PropertyValue",
+            "additionalType": "Number",
+            "name": "tissue-high-chunk",
+            "value": 1536
+        },
+        {
+            "@id": "#50c4d970-3a82-41eb-8e02-22c5831fc882",
+            "@type": "FormalParameter",
+            "additionalType": "Number",
+            "name": "tumor-chunk"
+        },
+        {
+            "@id": "#3d9580a3-5f6d-425d-a1ba-e566d2f9e6f7",
+            "@type": "PropertyValue",
+            "additionalType": "Number",
+            "name": "tumor-chunk",
+            "value": 1536
+        },
+        {
+            "@id": "#160c9d45-6cc3-4d46-ba62-a2bf033ff67e",
+            "@type": "FormalParameter",
+            "additionalType": "Number",
+            "name": "gpu"
+        },
+        {
+            "@id": "#ce94ae6d-c5dc-4e88-b008-855dc0287de5",
+            "@type": "PropertyValue",
+            "additionalType": "Number",
+            "name": "gpu",
+            "value": 0
+        },
+        {
+            "@id": "#ba92690c-9abf-4384-a2a7-07be0107dbcb",
+            "@type": "FormalParameter",
+            "additionalType": "Number",
+            "name": "tumor-level"
+        },
+        {
+            "@id": "#5234adbf-1dc2-44d6-a978-4e332ed1a93f",
+            "@type": "PropertyValue",
+            "additionalType": "Number",
+            "name": "tumor-level",
+            "value": 1
+        },
+        {
+            "@id": "#4719501a-2a3d-47c9-9b37-eb21bc637e88",
+            "@type": "FormalParameter",
+            "additionalType": "Text",
+            "name": "tumor-label"
+        },
+        {
+            "@id": "#6968a1c2-5364-4ad9-9379-edf90f557520",
+            "@type": "PropertyValue",
+            "additionalType": "Text",
+            "name": "tumor-label",
+            "value": "tumor"
+        },
+        {
+            "@id": "#215ab585-6fae-4df0-bea1-f7c9dcd25d94",
+            "@type": "FormalParameter",
+            "additionalType": "Text",
+            "name": "tumor-filter"
+        },
+        {
+            "@id": "#207fc4b4-a11e-42a4-bc49-92a668c9038f",
+            "@type": "PropertyValue",
+            "additionalType": "Text",
+            "name": "tumor-filter",
+            "value": "tissue_low>1"
+        },
+        {
+            "@id": "#b192cffb-6938-4efa-afad-fc364a38089e",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "tissue"
+        },
+        {
+            "@id": "tissue_high.zip",
+            "@type": "File",
+            "contentSize": 4099
+        },
+        {
+            "@id": "#a9de171d-411f-437c-8b59-1f6ede53361e",
+            "@type": "FormalParameter",
+            "additionalType": "File",
+            "name": "tumor"
+        },
+        {
+            "@id": "tumor.zip",
+            "@type": "File",
+            "contentSize": 70100
         }
     ]
 }


### PR DESCRIPTION
Updates the provenance RO-Crate according to recent developments in the [Workflow Run RO-Crate](https://www.researchobject.org/workflow-run-crate/) definition work.

Main changes:
* Adds a `CreateAction` containing references to start and end time, `instrument` (the workflow), `object` (inputs) and `result` (outputs)
* Parameter values have been removed from `FormalParameter` entries (since they represent input _slots_ rather than concrete realizations) and listed in `PropertyValue` entities referenced by the `CreateAction` instead
* Finer mapping of parameter types